### PR TITLE
Ensure we're not handling websocket events before the session is ready

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -202,10 +202,6 @@ func (wac *Conn) connect() (err error) {
 		wac.listener.onReconnect()
 	}
 
-	ws.Add(2)
-	go wac.readPump(ws)
-	go wac.keepAlive(ws, 21000, 30000)
-
 	wac.loggedIn = false
 	wac.adminInited = false
 	wac.log.Debugln("Successfully connected to websocket")

--- a/session.go
+++ b/session.go
@@ -261,6 +261,10 @@ Loop:
 	wac.session = &session
 	wac.loggedIn = true
 
+	wac.ws.Add(2)
+	go wac.readPump(wac.ws)
+	go wac.keepAlive(wac.ws, 21000, 30000)
+
 	return session, info.WID, nil
 }
 


### PR DESCRIPTION
The journey that took us here:

1. [`Conn.Login()`](https://github.com/vector-im/go-whatsapp/blob/a82432736d433303ddfda7487c962c37293da576/session.go#L112) gets called
2. [`Conn.connect()`](https://github.com/vector-im/go-whatsapp/blob/a82432736d433303ddfda7487c962c37293da576/conn.go#L155) gets called
3. [`Conn.connect()`](https://github.com/vector-im/go-whatsapp/blob/a82432736d433303ddfda7487c962c37293da576/conn.go#L206) starts a goroutine that starts reading the websocket and handling its inputs
4. **RACE**: In the aforementioned goroutine: a message comes in, gets picked up by a handler, ends up in [`handleMessageConn()`](https://github.com/vector-im/go-whatsapp/blob/a82432736d433303ddfda7487c962c37293da576/jsonmessage.go#L440) and assumes that `wac.session` is already initialized – wrongly, so it blows up
4. `Conn.Login()` regains control, [eventually initializing `wac.session`](https://github.com/vector-im/go-whatsapp/blob/a82432736d433303ddfda7487c962c37293da576/session.go#L261)

Log from a sample blowup:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7eb9c0]

goroutine 38099 [running]:
github.com/Rhymen/go-whatsapp.(*Conn).handleMessageConn(0xc023c94900, {0xc02cbd8000, 0x48d, 0x500})
        /go/pkg/mod/github.com/vector-im/go-whatsapp@v0.5.13-0.20211026112753-c997771d23df/jsonmessage.go:440 +0xc0
github.com/Rhymen/go-whatsapp.(*Conn).handleJSONMessage(0xc023c94900, {0xc0278ab403, 0x496})
        /go/pkg/mod/github.com/vector-im/go-whatsapp@v0.5.13-0.20211026112753-c997771d23df/jsonmessage.go:355 +0x2a5
github.com/Rhymen/go-whatsapp.(*Conn).processReadData(0xc023c94900, 0x1, {0xc0278aaf00, 0x0, 0x1})
        /go/pkg/mod/github.com/vector-im/go-whatsapp@v0.5.13-0.20211026112753-c997771d23df/read.go:191 +0x315
github.com/Rhymen/go-whatsapp.(*Conn).readPump(0xc023c94900, 0xc0245ae820)
        /go/pkg/mod/github.com/vector-im/go-whatsapp@v0.5.13-0.20211026112753-c997771d23df/read.go:143 +0x365
created by github.com/Rhymen/go-whatsapp.(*Conn).connect
        /go/pkg/mod/github.com/vector-im/go-whatsapp@v0.5.13-0.20211026112753-c997771d23df/conn.go:206 +0x431
```

This moves the goroutine setup from `Conn.connect()` to the end of `Conn.Login`, hopefully ensuring that we don't start handling events until we're actually ready for them.