### PR TITLE
Make sure stale, timed out logins don't cause crashes on later logins

### DIFF
--- a/session.go
+++ b/session.go
@@ -157,6 +157,16 @@ func (wac *Conn) Login(qrChan chan<- string, ctx context.Context) (Session, JID,
 
 	wac.loginSessionLock.Lock()
 	defer wac.loginSessionLock.Unlock()
+
+	defer func() {
+		if !wac.loggedIn {
+			// looks like we errored out somewhere along the way.
+			// close the connection to make sure nothing arrives later
+			// and confuses the message handlers
+			wac.Disconnect()
+		}
+	}()
+
 	if ctx == nil {
 		ctx = context.Background()
 	}


### PR DESCRIPTION
Since the websocket connection outlived the login flow, it would still
receive messages from future attempts while not being in the right state
to handle them, causing a segfault and a crash. This ensures we don't
keep the old connections around and there's no way for them to cause
trouble.